### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#ColorDialog & PromptDialog
+# ColorDialog & PromptDialog
 [![](https://jitpack.io/v/andyxialm/ColorDialog.svg)](https://jitpack.io/#andyxialm/ColorDialog)
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-ColorDialog-brightgreen.svg?style=flat)]()
 
@@ -122,5 +122,5 @@ new PromptDialog(this)
 ![](https://github.com/andyxialm/ColorDialog/blob/master/art/Screenshot_imgtext.png?raw=true)
 
 
-#License
+# License
 <p>ColorDialog is available under the MIT license.</p>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
