### PR TITLE
Fixed Alignment issue in Cancel Button when no image is provided.

### DIFF
--- a/ColorDialog/src/main/res/layout/layout_colordialog.xml
+++ b/ColorDialog/src/main/res/layout/layout_colordialog.xml
@@ -75,7 +75,7 @@
         <TextView
             android:id="@+id/btnPositive"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@drawable/sel_def_gray_left"
             android:clickable="true"
@@ -102,7 +102,7 @@
         <TextView
             android:id="@+id/btnNegative"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@drawable/sel_def_gray_right"
             android:clickable="true"


### PR DESCRIPTION
In colorDialog Layout:
Setting layout_height to "match_parent" solves the issue.
See below.

![Cancel Button Algned](https://user-images.githubusercontent.com/19947716/78153516-c50b0800-7458-11ea-878a-b7e2cc18b19c.jpeg)
